### PR TITLE
ミドルウェアでUIDを取得して，APIに渡すようにした

### DIFF
--- a/middleware/firebase.go
+++ b/middleware/firebase.go
@@ -43,6 +43,8 @@ func FirebaseAuth() gin.HandlerFunc {
 
 		fmt.Printf("Verified ID token: %v\n", token)
 
+		ctx.Set("UserID", token.UID)
+
 		ctx.Next()
 	}
 }


### PR DESCRIPTION
ミドルウェアでUIDを取得，gin.Contextに設定してAPIの関数で取得できるようにした．