### PR TITLE
Feature/fix firebase middleware

### DIFF
--- a/middleware/firebase.go
+++ b/middleware/firebase.go
@@ -41,7 +41,7 @@ func FirebaseAuth() gin.HandlerFunc {
 			return
 		}
 
-		fmt.Printf("Verified ID token: %v\n", token)
+		// fmt.Printf("Verified ID token: %v\n", token)
 
 		ctx.Set("FirebaseID", token.UID)
 

--- a/middleware/firebase.go
+++ b/middleware/firebase.go
@@ -43,7 +43,7 @@ func FirebaseAuth() gin.HandlerFunc {
 
 		fmt.Printf("Verified ID token: %v\n", token)
 
-		ctx.Set("UserID", token.UID)
+		ctx.Set("FirebaseID", token.UID)
 
 		ctx.Next()
 	}


### PR DESCRIPTION
ミドルウェアでcontextに設定するトークンのキーを"UserID"から"FirebaseID"に変更した．