### PR TITLE
GormのFirstを使用する際の条件の組み方を修正

### DIFF
--- a/api/profile.go
+++ b/api/profile.go
@@ -91,9 +91,9 @@ func EditProfile(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		// 更新前の情報を取得
-		firebaseID := c.MustGet("FirebaseID")
-		beforeUser := model.User{FirebaseID: firebaseID.(string)}
-		db.First(&beforeUser)
+		firebaseID := c.MustGet("FirebaseID").(string)
+		beforeUser := model.User{}
+		db.Where(&model.User{FirebaseID: firebaseID}).First(&beforeUser)
 
 		// 更新
 		db.Model(&beforeUser).Updates(user)


### PR DESCRIPTION
user := model.User{ID: 2}
db.First(&user)
のようにFirstの前に指定して要素を取れるのはPrimary Keyのみで，それ以外のフィールドを指定する場合は
db.Where(&model.User{FirebaseID: firebaseID}).First(&user)
の形を取る．